### PR TITLE
fix google maps bang

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -42540,7 +42540,7 @@ export const bangs = [
     s: "Google Maps",
     sc: "Maps",
     t: "gm",
-    u: "https://google.com/maps/place/{{{s}}}",
+    u: "https://google.com/maps/search/{{{s}}}",
   },
   {
     c: "Online Services",


### PR DESCRIPTION
Google maps changed the path for searching locations. As a european i am required to use this bang a lot as google does not link to maps on their main search anymore.